### PR TITLE
enable user name and profile pic by setting as_user to True

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -23,11 +23,13 @@ def remind():
         "chat.postMessage",
         channel='general',
         text='@here It is time for a coffee break!',
-        link_names=True
+        link_names=True,
+        as_user=True
     )
 
+
 # constants
-RTM_READ_DELAY = 20 # 1 second delay between reading from RTM
+RTM_READ_DELAY = 20  # 1 second delay between reading from RTM
 EXAMPLE_COMMAND = "do"
 MENTION_REGEX = "^<@(|[WU].+?)>(.*)"
 


### PR DESCRIPTION
Currently the coffee bot does not show it's profile picture and profile name when it notifies us for the coffee break on slack. This change should solve the issue and display a nice cup of coffee and the profile name "coffeebreakbot"